### PR TITLE
Add info about Java on the requirements page

### DIFF
--- a/users/install.html
+++ b/users/install.html
@@ -28,7 +28,7 @@ If you’re on the 8.10 version, please install Java manually from the <a href="
 <strong>ArchLinux users</strong>: a community package is available <a href="http://aur.archlinux.org/packages.php?ID=43580">here</a>.</p>
 <h2>Troubleshooting</h2>
 
-<h3>Gephi does not start or closes unexpectedly upon start</h3>
+<h3 id="gephi-does-not-start">Gephi does not start or closes unexpectedly upon start</h3>
 Gephi 0.8.2 has a known problem that causes it to crash in Mac OS since Java 7 and Windows since Java 8.
 These problems will be fixed in next release.
 

--- a/users/requirements.html
+++ b/users/requirements.html
@@ -5,6 +5,7 @@ sidebar: users
 ---
 
 <p>Gephi is a cross-platform application, as it is developed in Java. It was successfully tested on many different architecture, OS and graphical configuration. Gephi requires Java version 6 and later, get it <a href="http://www.java.com/getjava">here</a>.</p>
+
 <h3>Minimum hardware requirements</h3>
 <p>500 MHz CPU + 128 MB RAM + OpenGL 1.2<br />
 There is no absolute minimum. This is a practical minimum. Performance is a function of graph size.</p>
@@ -36,12 +37,17 @@ There is no absolute minimum. This is a practical minimum. Performance is a func
 </tbody>
 </table>
 <p>Note that Gephi has been successfully tested on Netbooks, running on Intel® Atom.</p>
+
 <h3>Graphics</h3>
 <p>Gephi uses an OpenGL 3D engine to speed up graph visualization. However a compatible graphic card is required. If your graphic card is  older than 5 years, or if your laptop doesn&#8217;t have a dedicated graphic card, you may have to upgrade your hardware to run Gephi.</p>
 <ul>
 <li><a href="/users/detect-and-fix-graphical-problems/">Detect and fix graphical problems</a></li>
 </ul>
 <p>If you&#8217;re running on Linux, get latest vendor graphical drivers to ensure OpenGL hardware acceleration.</p>
+
+<h3>Java</h3>
+The current stable version of Gephi will only run with Java 6 or 7 (i.e. not Java 8) on both Windows and Linux. On Mac OS, it works with Java 6 only. See <a href="/users/install#gephi-does-not-start">the installation instructions</a>.
+
 <h3>Mac OS X</h3>
 <p>Java 1.6 is unfortunately only available on 64-bit Intel Macs. The community is waiting for a full 1.6 support.</p>
 <p>For Macs that can have Java 6, see how to enable it: <a href="/users/install-java-6-mac-os-x-leopard">Install Java 6 on Mac  OS X Leopard</a></p>


### PR DESCRIPTION
Another fix for gephi/gephi#1142

IMO the info should be present on the Requirements page as well.